### PR TITLE
Update to Google Cloud 151

### DIFF
--- a/ewok.yml
+++ b/ewok.yml
@@ -11,11 +11,9 @@ build:
         - script:
             name: config
             code: |
-                GCLOUD_VERSION="127.0.0-linux-x86_64"
+                GCLOUD_VERSION="151.0.0-linux-x86_64"
                 export GCLOUD_DIRNAME="google-cloud-sdk"
-                export KUBERNETES_VERSION="1.6.0"
-                export KUBERNETES_SHA256="c488d77cd980ca7dae03bc684e19bd6a329962e32ed7a1bc9c4d560ed433399a"
-                export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
+                export GCLOUD_SHA="53caea9133e3ed0efe26164e8a29751a3caf770f"
                 export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
                 export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"
                 export UPX_VERSION="3.93"
@@ -38,16 +36,6 @@ build:
             name: Extract upx archive
             code: |
                 tar -xf ${UPX_FILENAME}
-
-        - script:
-            name: fetch kubernetes archive
-            code: |
-                curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl > $WERCKER_OUTPUT_DIR/kubectl
-
-        - script:
-            name: validate kubernetes archive
-            code: |
-                cat $WERCKER_OUTPUT_DIR/kubectl| sha256sum | grep -q "$KUBERNETES_SHA256"
 
         - script:
             name: Fetch gcloud archive
@@ -78,13 +66,21 @@ build:
             name: prepare output
             code: |
                 cp  "${WERCKER_ROOT}/LICENSE" "${WERCKER_ROOT}/README.md" "${WERCKER_ROOT}/run.sh" "${WERCKER_ROOT}/wercker.yml" "${WERCKER_ROOT}/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
+                cd $WERCKER_OUTPUT_DIR
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
-                chmod ugo+rx "$WERCKER_OUTPUT_DIR/kubectl"
+                rm -rf "${GCLOUD_DIRNAME}/platform/gsutil"
+                ln -sf ${GCLOUD_DIRNAME}/bin/kubectl kubectl
 
         - script:
             name: Compress kubectl
             code: |
-                ${UPX_DIRNAME}/upx $WERCKER_OUTPUT_DIR/kubectl
+                ${UPX_DIRNAME}/upx -1 "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/kubectl"
+
+        - script:
+            name: Measure output folder
+            code: |
+                du -csh $WERCKER_OUTPUT_DIR/*
+                du -csh $WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/*
 
 test-busybox:
     box:

--- a/ewok.yml
+++ b/ewok.yml
@@ -21,7 +21,7 @@ build:
                 export UPX_DIRNAME="upx-${UPX_VERSION}-amd64_linux"
                 export UPX_FILENAME="${UPX_DIRNAME}.tar.xz"
                 export UPX_URL="https://github.com/upx/upx/releases/download/v${UPX_VERSION}/${UPX_FILENAME}"
-                echo "Installing version $KUBERNETES_VERSION of kubernetes and ${GCLOUD_VERSION} of the Google Cloud SDK"
+                echo "Installing version ${GCLOUD_VERSION} of the Google Cloud SDK"
         - script:
             name: fetch upx
             code: |

--- a/ewok.yml
+++ b/ewok.yml
@@ -13,8 +13,8 @@ build:
             code: |
                 GCLOUD_VERSION="127.0.0-linux-x86_64"
                 export GCLOUD_DIRNAME="google-cloud-sdk"
-                export KUBERNETES_VERSION="1.3.4"
-                export KUBERNETES_SHA256="81f0e3c788241419be1ee961da8804fdb16657b86e7edba8c7070932e8a50fe7"
+                export KUBERNETES_VERSION="1.6.0"
+                export KUBERNETES_SHA256="c488d77cd980ca7dae03bc684e19bd6a329962e32ed7a1bc9c4d560ed433399a"
                 export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
                 export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
                 export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"

--- a/ewok.yml
+++ b/ewok.yml
@@ -69,7 +69,6 @@ build:
                 cd $WERCKER_OUTPUT_DIR
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
                 rm -rf "${GCLOUD_DIRNAME}/platform/gsutil"
-                ln -sf ${GCLOUD_DIRNAME}/bin/kubectl kubectl
 
         - script:
             name: Compress kubectl

--- a/ewok.yml
+++ b/ewok.yml
@@ -18,7 +18,26 @@ build:
                 export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
                 export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
                 export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"
+                export UPX_VERSION="3.93"
+                export UPX_SHA="db4ec36b930e7d7e082d93124a59d38fbaedd1c0"
+                export UPX_DIRNAME="upx-${UPX_VERSION}-amd64_linux"
+                export UPX_FILENAME="${UPX_DIRNAME}.tar.xz"
+                export UPX_URL="https://github.com/upx/upx/releases/download/v${UPX_VERSION}/${UPX_FILENAME}"
                 echo "Installing version $KUBERNETES_VERSION of kubernetes and ${GCLOUD_VERSION} of the Google Cloud SDK"
+        - script:
+            name: fetch upx
+            code: |
+                curl -L ${UPX_URL} -o ${UPX_FILENAME}
+
+        - script:
+            name: validate upx archive
+            code: |
+                sha1sum ${UPX_FILENAME} | grep -q "${UPX_SHA}"
+
+        - script:
+            name: Extract upx archive
+            code: |
+                tar -xf ${UPX_FILENAME}
 
         - script:
             name: fetch kubernetes archive
@@ -61,6 +80,11 @@ build:
                 cp  "${WERCKER_ROOT}/LICENSE" "${WERCKER_ROOT}/README.md" "${WERCKER_ROOT}/run.sh" "${WERCKER_ROOT}/wercker.yml" "${WERCKER_ROOT}/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/kubectl"
+
+        - script:
+            name: Compress kubectl
+            code: |
+                ${UPX_DIRNAME}/upx $WERCKER_OUTPUT_DIR/kubectl
 
 test-busybox:
     box:

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 GCLOUD_INSTALL_DIR="$WERCKER_STEP_ROOT/google-cloud-sdk/bin/"
-kubectl="$WERCKER_STEP_ROOT/kubectl"
+kubectl="$GCLOUD_INSTALL_DIR/kubectl"
 
 gcloud_auth_config() {
 

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: kubectl
-version: 3.1.8
+version: 3.1.9
 description: Step to run kubectl, with support for GKE clusters.
 keywords:
   - kubernetes

--- a/wercker.yml
+++ b/wercker.yml
@@ -8,8 +8,8 @@ build:
             code: |
                 GCLOUD_VERSION="127.0.0-linux-x86_64"
                 export GCLOUD_DIRNAME="google-cloud-sdk"
-                export KUBERNETES_VERSION="1.3.4"
-                export KUBERNETES_SHA256="81f0e3c788241419be1ee961da8804fdb16657b86e7edba8c7070932e8a50fe7"
+                export KUBERNETES_VERSION="1.6.0"
+                export KUBERNETES_SHA256="c488d77cd980ca7dae03bc684e19bd6a329962e32ed7a1bc9c4d560ed433399a"
                 export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
                 export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
                 export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"

--- a/wercker.yml
+++ b/wercker.yml
@@ -16,7 +16,7 @@ build:
                 export UPX_DIRNAME="upx-${UPX_VERSION}-amd64_linux"
                 export UPX_FILENAME="${UPX_DIRNAME}.tar.xz"
                 export UPX_URL="https://github.com/upx/upx/releases/download/v${UPX_VERSION}/${UPX_FILENAME}"
-                echo "Installing version $KUBERNETES_VERSION of kubernetes and ${GCLOUD_VERSION} of the Google Cloud SDK"
+                echo "Installing version ${GCLOUD_VERSION} of the Google Cloud SDK"
         - script:
             name: fetch upx
             code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -13,7 +13,26 @@ build:
                 export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
                 export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
                 export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"
+                export UPX_VERSION="3.93"
+                export UPX_SHA="db4ec36b930e7d7e082d93124a59d38fbaedd1c0"
+                export UPX_DIRNAME="upx-${UPX_VERSION}-amd64_linux"
+                export UPX_FILENAME="${UPX_DIRNAME}.tar.xz"
+                export UPX_URL="https://github.com/upx/upx/releases/download/v${UPX_VERSION}/${UPX_FILENAME}"
                 echo "Installing version $KUBERNETES_VERSION of kubernetes and ${GCLOUD_VERSION} of the Google Cloud SDK"
+        - script:
+            name: fetch upx
+            code: |
+                curl -L ${UPX_URL} -o ${UPX_FILENAME}
+
+        - script:
+            name: validate upx archive
+            code: |
+                sha1sum ${UPX_FILENAME} | grep -q "${UPX_SHA}"
+
+        - script:
+            name: Extract upx archive
+            code: |
+                tar -xf ${UPX_FILENAME}
 
         - script:
             name: fetch kubernetes archive
@@ -56,3 +75,9 @@ build:
                 cp  "${WERCKER_ROOT}/LICENSE" "${WERCKER_ROOT}/README.md" "${WERCKER_ROOT}/run.sh" "${WERCKER_ROOT}/wercker.yml" "${WERCKER_ROOT}/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/kubectl"
+
+        - script:
+            name: Compress kubectl
+            code: |
+                ${UPX_DIRNAME}/upx $WERCKER_OUTPUT_DIR/kubectl
+

--- a/wercker.yml
+++ b/wercker.yml
@@ -6,11 +6,9 @@ build:
         - script:
             name: config
             code: |
-                GCLOUD_VERSION="127.0.0-linux-x86_64"
+                GCLOUD_VERSION="151.0.0-linux-x86_64"
                 export GCLOUD_DIRNAME="google-cloud-sdk"
-                export KUBERNETES_VERSION="1.6.0"
-                export KUBERNETES_SHA256="c488d77cd980ca7dae03bc684e19bd6a329962e32ed7a1bc9c4d560ed433399a"
-                export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
+                export GCLOUD_SHA="53caea9133e3ed0efe26164e8a29751a3caf770f"
                 export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
                 export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"
                 export UPX_VERSION="3.93"
@@ -33,16 +31,6 @@ build:
             name: Extract upx archive
             code: |
                 tar -xf ${UPX_FILENAME}
-
-        - script:
-            name: fetch kubernetes archive
-            code: |
-                curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl > $WERCKER_OUTPUT_DIR/kubectl
-
-        - script:
-            name: validate kubernetes archive
-            code: |
-                cat $WERCKER_OUTPUT_DIR/kubectl| sha256sum | grep -q "$KUBERNETES_SHA256"
 
         - script:
             name: Fetch gcloud archive
@@ -73,11 +61,19 @@ build:
             name: prepare output
             code: |
                 cp  "${WERCKER_ROOT}/LICENSE" "${WERCKER_ROOT}/README.md" "${WERCKER_ROOT}/run.sh" "${WERCKER_ROOT}/wercker.yml" "${WERCKER_ROOT}/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
+                cd $WERCKER_OUTPUT_DIR
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
-                chmod ugo+rx "$WERCKER_OUTPUT_DIR/kubectl"
+                rm -rf "${GCLOUD_DIRNAME}/platform/gsutil"
+                rm -rf "${GCLOUD_DIRNAME}/platform/bq"
+                ln -sf ${GCLOUD_DIRNAME}/bin/kubectl kubectl
 
         - script:
             name: Compress kubectl
             code: |
-                ${UPX_DIRNAME}/upx $WERCKER_OUTPUT_DIR/kubectl
+                ${UPX_DIRNAME}/upx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/kubectl"
 
+        - script:
+            name: Measure output folder
+            code: |
+                du -csh $WERCKER_OUTPUT_DIR/*
+                du -csh $WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/*

--- a/wercker.yml
+++ b/wercker.yml
@@ -65,7 +65,6 @@ build:
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
                 rm -rf "${GCLOUD_DIRNAME}/platform/gsutil"
                 rm -rf "${GCLOUD_DIRNAME}/platform/bq"
-                ln -sf ${GCLOUD_DIRNAME}/bin/kubectl kubectl
 
         - script:
             name: Compress kubectl


### PR DESCRIPTION
This updates the Google SDK to 151 which includes kubectl 1.6.0.

When doing this I hit a Wercker bug (or feature?) where a step has a maximum size of 50MB. How I got around this is explained in commit 3dc01e658854f1b59975e6ac6650889ea7cc6675.

I can rebase etc. as needed, just let me know.