### PR TITLE
remove tail slash for the correct path

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-GCLOUD_INSTALL_DIR="$WERCKER_STEP_ROOT/google-cloud-sdk/bin/"
+GCLOUD_INSTALL_DIR="$WERCKER_STEP_ROOT/google-cloud-sdk/bin"
 kubectl="$GCLOUD_INSTALL_DIR/kubectl"
 
 gcloud_auth_config() {


### PR DESCRIPTION
This PR avoids double slashes for gcloud and kuberctl path such as `"$WERCKER_STEP_ROOT/google-cloud-sdk/bin//gcloud`.